### PR TITLE
Change basis for selectivity estimation for operator scan predicate with ColumnVsValue

### DIFF
--- a/src/lib/statistics/cardinality_estimator.cpp
+++ b/src/lib/statistics/cardinality_estimator.cpp
@@ -748,7 +748,7 @@ std::shared_ptr<TableStatistics> CardinalityEstimator::estimate_operator_scan_pr
         if (input_table_statistics->row_count == 0 || sliced_histogram->total_count() == 0.0f) {
           selectivity = 0.0f;
         } else {
-          selectivity = sliced_histogram->total_count() / scan_statistics_object->total_count();
+          selectivity = sliced_histogram->total_count() / input_table_statistics->row_count;
         }
 
         const auto column_statistics = std::make_shared<AttributeStatistics<ColumnDataType>>();


### PR DESCRIPTION
This PR improves the cardinality estimation for ColumnVsValue Operator Scan Predicates by fixing a faulty selectivity calculation. 

To estimate the cardinality of a result table after a Scan Predicate Operator comparing a Column vs. a Value was applied, the following steps happen:
1. If the predicate_condition is not one of `{IS (NOT) NULL, (NOT) LIKE, BETWEEN ... AND .. }` (these are handled in a separate case), the previously calculated histogram of values in the Column is sliced according to the predicate. The sliced histogram then only holds the values of the column that fulfill the predicate. 
```cpp 
737 const auto sliced_statistics_object =
            scan_statistics_object->sliced(predicate.predicate_condition, value_variant, value2_variant);
```
            
2. As a next step the selectivity of the predicate on the column is calculated as: 
```cpp
751  selectivity = sliced_histogram->total_count() / scan_statistics_object->total_count();
``` 
Here `scan_statistics_object` holds the previous, not-sliced histogram. This means that the selectivity is calculated based on the total_count of values in the histogram. 

3. Finally the other columns `AttributeStatistics` are scaled according to the calculated selectivity, and the new row_count estimation for the result table is calculated as: 
```cpp
774 const auto row_count = Cardinality{input_table_statistics->row_count * selectivity};
```
So the selectivity is applied on the row_count of the input_table. 

The estimation error is caused by the fact that histograms do not hold `NULL` values. Therefore the `row_count` of the `input_table_statistics` object can be different from the `total_count` of the histograms for the table's columns. (See next example picture of the `cast_info` table from the IMDb benchmark, which prints the value count of each column statistics object.)
As the selectivity is applied on the input_table, it should be calculated based on the row_count of the input_table and not on the differing values count in the histogram.

![image](https://user-images.githubusercontent.com/34538290/124492073-42d46680-ddb4-11eb-888d-674e3a97add3.png)

We argue that as `NULL` isn't a value in SQL and therefore cannot be compared to values, `NULL` values will have to be excluded from the estimates, and therefore should be included in the selectivity calculation. This is what happens if we calculate the selectivity based on `input_table_statistics->row_count`. As far as we can see, this should hold for all relevant cases (`Equal, NotEqual, Less/GreaterThan(Equals), Between*`), as a comparison against a value would always exclude `NULL` values in these cases. 

In estimations for other Operator Types (e.g. `inner_equi_join` and `semi_join`), the selectivity is actually already being calculated like this. 

```cpp
912 const auto left_selectivity = Selectivity{
        left_input_table_statistics.row_count > 0 ? cardinality / left_input_table_statistics.row_count : 0.0f};
```

TODO:
- [x] Compare cardinality benchmark results with improvement against previous cardinality estimations to verify impact.

Comparing the estimated cardinality of the result table of the JoinOrderBenchmark Queries, we see only improvements in estimation or equal estimations. (The only exception are queries with an estimated cardinality of lower 1, which are now sometimes estimated with even lower cardinalities. However, as the actual row count is always 1 in the PQPs, estimating a bit lower shouldn't be that negatively impactful. Also, these estimations are comparatively very much on target and were not the target of our improvement approaches.)

The differences in estimation are not always big, but the overall trend is definitely positive.
[join_order_benchmark_cardinality_comparison.csv](https://github.com/leowe/hyrise/files/6765475/join_order_benchmark_cardinality_comparison.csv)
